### PR TITLE
feat: use GenServers and Supervisors to handle API calls and data cache

### DIFF
--- a/apps/dashboard/lib/dashboard/application.ex
+++ b/apps/dashboard/lib/dashboard/application.ex
@@ -10,9 +10,10 @@ defmodule Dashboard.Application do
       # Start the Ecto repository
       Dashboard.Repo,
       # Start the PubSub system
-      {Phoenix.PubSub, name: Dashboard.PubSub}
+      {Phoenix.PubSub, name: Dashboard.PubSub},
       # Start a worker by calling: Dashboard.Worker.start_link(arg)
       # {Dashboard.Worker, arg}
+      {DynamicSupervisor, strategy: :one_for_one, name: Dashboard.Stores.DynamicSupervisor}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: Dashboard.Supervisor)

--- a/apps/dashboard/lib/dashboard/stores.ex
+++ b/apps/dashboard/lib/dashboard/stores.ex
@@ -1,0 +1,16 @@
+defmodule Dashboard.Stores do
+  def subscribe(name, subscriber_pid, component, user) do
+    pid =
+      case Dashboard.Stores.DynamicSupervisor.start_child(name, component, user) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+
+    :ok = Dashboard.Stores.ComponentStore.subscribe(pid, subscriber_pid)
+    {:ok, pid}
+  end
+
+  def unsubscribe(name, subscriber_pid) do
+    Dashboard.Stores.ComponentStore.unsubscribe({:global, name}, subscriber_pid)
+  end
+end

--- a/apps/dashboard/lib/dashboard/stores/component_store.ex
+++ b/apps/dashboard/lib/dashboard/stores/component_store.ex
@@ -1,0 +1,143 @@
+defmodule Dashboard.Stores.ComponentStore do
+  use GenServer
+
+  @poll_interval 20_000
+
+  require Logger
+
+  def start_link(opts \\ []) do
+    opts = Keyword.merge([name: __MODULE__], opts)
+    GenServer.start_link(__MODULE__, %{component: opts[:component], user: opts[:user]}, opts)
+  end
+
+  def subscribe(pid, subscriber_pid) do
+    GenServer.cast(pid, {:subscribe, subscriber_pid})
+  end
+
+  def unsubscribe(pid, subscriber_pid) do
+    GenServer.cast(pid, {:unsubscribe, subscriber_pid})
+  end
+
+  def get(pid, keyword) do
+    GenServer.call(pid, {:get, keyword})
+  end
+
+  def get_all(pid) do
+    GenServer.call(pid, :get_all)
+  end
+
+  def cancel_updates(pid) do
+    GenServer.cast(pid, :cancel_updates)
+  end
+
+  def inspect(pid) do
+    GenServer.call(pid, :inspect)
+  end
+
+  # ┌──────────────────┐
+  # │ Server Callbacks │
+  # └──────────────────┘
+
+  def init(state) do
+    {:ok, timer} = :timer.send_interval(@poll_interval, :update)
+
+    state =
+      state
+      |> Map.put(state.component.assign, [])
+      |> Map.put(:subscribers, [])
+      |> Map.put(:timer, timer)
+
+    {:ok, state}
+  end
+
+  def handle_call({:get, keyword}, _, state) do
+    {:reply, Map.get(state, keyword, []), state}
+  end
+
+  def handle_call(:get_all, _, state) do
+    {:reply, Map.get(state, state.component.assign, []), state}
+  end
+
+  def handle_call(:inspect, _, state) do
+    {:reply, state, state}
+  end
+
+  def handle_cast(:cancel_updates, %{timer: nil} = state), do: {:noreply, state}
+
+  def handle_cast(:cancel_updates, %{timer: timer} = state) do
+    :timer.cancel(timer)
+    {:noreply, %{state | timer: nil}}
+  end
+
+  def handle_cast({:subscribe, subscriber_pid}, %{subscribers: subscribers} = state) do
+    Process.monitor(subscriber_pid)
+
+    subscribers =
+      [subscriber_pid | subscribers]
+      |> Enum.uniq()
+
+    Logger.debug(
+      "New subscriber (#{Kernel.inspect(subscriber_pid)}) to #{Kernel.inspect(self())}. #{
+        Kernel.inspect(subscribers)
+      }"
+    )
+
+    {:noreply, %{state | subscribers: subscribers}}
+  end
+
+  def handle_cast({:unsubscribe, subscriber_pid}, %{subscribers: subscribers} = state) do
+    subscribers =
+      subscribers
+      |> Enum.filter(fn subscriber ->
+        subscriber != subscriber_pid
+      end)
+
+    Logger.debug(
+      "Removed subscriber (#{Kernel.inspect(subscriber_pid)}) from #{Kernel.inspect(self())}. #{
+        Kernel.inspect(subscribers)
+      }"
+    )
+
+    {:noreply, %{state | subscribers: subscribers}}
+  end
+
+  def handle_info(:update, state) do
+    state =
+      Map.put(
+        state,
+        state.component.assign,
+        state.user
+        |> Dashboard.PlanningCenterApi.Client.get(state.component.api_path)
+        |> Map.get(:body, %{})
+        |> Map.get("data", [])
+      )
+
+    {:noreply, state}
+  end
+
+  @doc """
+  Unsubscribe a subscribed process when it goes down
+
+  We receive this message because we previously used `Process.monitor/1`
+  to monitor the process. If the process has already been subscribed (because
+  the LiveView handled the termination, for example), this could result
+  in two calls to `unsubscribe/2`, but I don't think that is a big deal.
+  """
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    __MODULE__.unsubscribe(self(), pid)
+    {:noreply, state}
+  end
+
+  # def terminate(reason, state) do
+  #   :ok
+  # end
+
+  def terminate(reason, state) do
+    :timer.cancel(state.timer)
+    :ok
+  end
+
+  # ┌──────────────────┐
+  # │ Helper Functions │
+  # └──────────────────┘
+end

--- a/apps/dashboard/lib/dashboard/stores/dynamic_supervisor.ex
+++ b/apps/dashboard/lib/dashboard/stores/dynamic_supervisor.ex
@@ -1,0 +1,19 @@
+defmodule Dashboard.Stores.DynamicSupervisor do
+  use DynamicSupervisor
+
+  def start_link(args \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def start_child(name, component, user) do
+    DynamicSupervisor.start_child(
+      __MODULE__,
+      {Dashboard.Stores.ComponentStore, name: {:global, name}, component: component, user: user}
+    )
+  end
+
+  @impl true
+  def init(_args) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/apps/dashboard_web/lib/dashboard_web/live/components/forms_overview.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/components/forms_overview.ex
@@ -9,14 +9,8 @@ defmodule DashboardWeb.Components.FormsOverview do
   end
 
   @impl true
-  def update(%{component: component, user_token: user_token}, socket) do
-    user = Accounts.get_user_by_session_token(user_token)
-
-    forms =
-      user
-      |> Dashboard.PlanningCenterApi.Client.get(component.api_path)
-      |> Map.get(:body, %{})
-      |> Map.get("data", [])
+  def update(assigns, socket) do
+    forms = Dashboard.Stores.ComponentStore.get({:global, get_id(assigns)}, "forms")
 
     {:ok, assign(socket, :forms, forms)}
   end
@@ -51,5 +45,9 @@ defmodule DashboardWeb.Components.FormsOverview do
       </div>
     </div>
     """
+  end
+
+  def get_id(assigns) do
+    "forms_overview--user_#{assigns.user_id}"
   end
 end

--- a/apps/dashboard_web/lib/dashboard_web/live/components/person_updated.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/components/person_updated.ex
@@ -9,18 +9,8 @@ defmodule DashboardWeb.Components.PersonUpdated do
   end
 
   @impl true
-  @spec update(
-          %{component: atom | %{api_path: any}, user_token: any},
-          Phoenix.LiveView.Socket.t()
-        ) :: {:ok, Phoenix.LiveView.Socket.t()}
-  def update(%{component: component} = assigns, socket) do
-    user = Accounts.get_user_by_session_token(assigns.user_token)
-
-    people =
-      user
-      |> Dashboard.PlanningCenterApi.Client.get(component.api_path)
-      |> Map.get(:body, %{})
-      |> Map.get("data", [])
+  def update(assigns, socket) do
+    people = Dashboard.Stores.ComponentStore.get({:global, get_id(assigns)}, "people")
 
     {:ok, assign(socket, :people, people)}
   end
@@ -53,5 +43,9 @@ defmodule DashboardWeb.Components.PersonUpdated do
       </div>
     </div>
     """
+  end
+
+  def get_id(assigns) do
+    "person_updated--user_#{assigns.user_id}"
   end
 end

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
@@ -5,6 +5,7 @@ defmodule DashboardWeb.DashboardLive.Layout do
   alias Dashboard.Dashboards.Component
 
   @impl true
+  # TODO: can all this be done with a user_id instead of a user_token?
   def mount(_params, %{"user_token" => user_token} = _session, socket) do
     {:ok,
      socket

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.ex
@@ -4,12 +4,9 @@ defmodule DashboardWeb.DashboardLive.Show do
   alias Dashboard.{Accounts, Dashboards}
   alias Dashboard.Dashboards.Component
 
-  @poll_interval 10_000
-
   @impl true
   def mount(_params, %{"user_token" => user_token} = _session, socket) do
     user = Accounts.get_user_by_session_token(user_token)
-    :timer.send_interval(@poll_interval, :tell_components_to_update)
 
     {:ok,
      socket

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.ex
@@ -4,25 +4,43 @@ defmodule DashboardWeb.DashboardLive.Show do
   alias Dashboard.{Accounts, Dashboards}
   alias Dashboard.Dashboards.Component
 
-  @poll_interval 30_000
+  @poll_interval 10_000
 
   @impl true
   def mount(_params, %{"user_token" => user_token} = _session, socket) do
+    user = Accounts.get_user_by_session_token(user_token)
     :timer.send_interval(@poll_interval, :tell_components_to_update)
 
     {:ok,
      socket
      |> assign(:components, [])
-     |> assign(:user_token, user_token)}
+     |> assign(:user_id, user.id)}
   end
 
   @impl true
   def handle_params(%{"slug" => slug}, _, socket) do
-    user = Accounts.get_user_by_session_token(socket.assigns.user_token)
-    dashboard = Dashboards.get_dashboard_by_slug!(slug, user.id)
+    user = Accounts.get_user!(socket.assigns.user_id)
+    dashboard = Dashboards.get_dashboard_by_slug!(slug, socket.assigns.user_id)
+
+    component_subscriptions =
+      dashboard.dashboard_components
+      |> Enum.map(fn dc ->
+        name = Dashboard.Dashboards.Component.to_module(dc.component).get_id(socket.assigns)
+
+        {:ok, pid} =
+          Dashboard.Stores.subscribe(
+            name,
+            self(),
+            dc.component,
+            user
+          )
+
+        {name, pid}
+      end)
 
     {:noreply,
      socket
+     |> assign(:component_subscriptions, component_subscriptions)
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:components, dashboard.dashboard_components)
      |> assign(:dashboard, dashboard)}
@@ -34,11 +52,17 @@ defmodule DashboardWeb.DashboardLive.Show do
       send_update(Component.to_module(dc.component),
         id: dc.id,
         component: dc.component,
-        user_token: socket.assigns.user_token
+        user_id: socket.assigns.user_id
       )
     end)
 
     {:noreply, socket}
+  end
+
+  @impl true
+  def terminate(_reason, socket) do
+    socket.assigns.component_subscriptions
+    |> Enum.each(fn {name, _pid} -> Dashboard.Stores.unsubscribe(name, self()) end)
   end
 
   defp page_title(:show), do: "Show Dashboard"

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.html.leex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.html.leex
@@ -2,7 +2,7 @@
   <%= for dc <- @components do %>
     <%= live_component(@socket,
                       Dashboard.Dashboards.Component.to_module(dc.component),
-                      user_token: @user_token,
+                      user_id: @user_id,
                       id: dc.id,
                       component: dc.component) %>
   <% end %>


### PR DESCRIPTION
- Instead of having each component fetch its own data from the API on every update (which means multiple fetches could occur on a single page for the same information if a component is rendered more than once), a dynamically-generated GenServer is created that handles the  fetching and data. When the GenServer is generated dynamically, it uses a computed name -- the component name and the user id. This means that every component with that name rendered by that user will share the same data. Furthermore, this means that an infinite number of components could be rendered on an infinite number of dashboards and as long as the same logged-in user was looking at the dashboard, it would make 1 total api call to Planning Center.

  Not only does this greatly reduce the load on Planning Center's API, it reduces the load we have to do to get that information and distribute it across all the instances of the same component.

- Instead of polling the view and having the components render based on that time, have the store tell all the subscribers when there is new data available.