### PR TITLE
feat: configure components on add

### DIFF
--- a/apps/dashboard/lib/dashboard/dashboards.ex
+++ b/apps/dashboard/lib/dashboard/dashboards.ex
@@ -258,6 +258,38 @@ defmodule Dashboard.Dashboards do
     end
   end
 
+  def create_dashboard_component_and_configurations(attrs, configurations) do
+    configurations_multi =
+      configurations
+      |> Enum.reduce(Ecto.Multi.new(), fn configuration, query ->
+        query
+        |> Ecto.Multi.run(
+          "create_configuration_for_#{Map.get(configuration, "configuration_id")}",
+          fn _,
+             %{
+               dashboard_component: %{
+                 id: dashboard_component_id
+               }
+             } ->
+            ComponentConfiguration.changeset(
+              %ComponentConfiguration{},
+              Map.put(configuration, "dashboard_component_id", dashboard_component_id)
+            )
+            |> Repo.insert()
+          end
+        )
+      end)
+
+    Ecto.Multi.new()
+    |> Ecto.Multi.run(:dashboard_component, fn _, changes ->
+      %DashboardComponent{}
+      |> DashboardComponent.changeset(attrs)
+      |> Repo.insert()
+    end)
+    |> Ecto.Multi.append(configurations_multi)
+    |> Repo.transaction()
+  end
+
   def delete_dashboard_component(%DashboardComponent{} = dc) do
     components =
       from(d in DashboardComponent,

--- a/apps/dashboard/lib/dashboard/dashboards.ex
+++ b/apps/dashboard/lib/dashboard/dashboards.ex
@@ -154,7 +154,9 @@ defmodule Dashboard.Dashboards do
 
   """
   def list_components do
-    Repo.all(Component)
+    Component
+    |> Repo.all()
+    |> Repo.preload(:configurations)
   end
 
   @doc """

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
@@ -26,6 +26,28 @@ defmodule DashboardWeb.DashboardLive.Layout do
   end
 
   @impl true
+  def handle_event("save", %{"component" => %{"component_id" => component_id}}, socket) do
+    user = Accounts.get_user_by_session_token(socket.assigns.user_token)
+    dashboard = socket.assigns.dashboard
+
+    # TODO: handle the error!
+    # TODO: is the double-reverse of the list faster or slower than appending the list directly?
+    case Dashboards.create_dashboard_component(%{
+           dashboard_id: dashboard.id,
+           component_id: component_id,
+           user_id: user.id
+         }) do
+      {:ok, dc} ->
+        {:noreply,
+         assign(
+           socket,
+           :dashboard_components,
+           Enum.reverse([dc | Enum.reverse(socket.assigns.dashboard_components)])
+         )}
+    end
+  end
+
+  @impl true
   def handle_event("add-component", %{"component-id" => component_id}, socket) do
     user = Accounts.get_user_by_session_token(socket.assigns.user_token)
     dashboard = socket.assigns.dashboard

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
@@ -26,34 +26,52 @@ defmodule DashboardWeb.DashboardLive.Layout do
   end
 
   @impl true
-  def handle_event("save", %{"component" => %{"component_id" => component_id}}, socket) do
+  def handle_event("add-component", %{"component" => %{"has_config" => "true"} = params}, socket) do
     user = Accounts.get_user_by_session_token(socket.assigns.user_token)
     dashboard = socket.assigns.dashboard
 
+    configs =
+      params
+      |> Enum.reduce([], fn {key, val}, list ->
+        case Regex.run(~r|^configuration_(\d)+|, key) do
+          nil ->
+            list
+
+          [_full_key, id] ->
+            [%{"configuration_id" => id, "value" => val} | list]
+        end
+      end)
+
     # TODO: handle the error!
-    # TODO: is the double-reverse of the list faster or slower than appending the list directly?
-    case Dashboards.create_dashboard_component(%{
-           dashboard_id: dashboard.id,
-           component_id: component_id,
-           user_id: user.id
-         }) do
+    # TODO: maybe DRY this up a bit along with unconfigurable components
+    case Dashboards.create_dashboard_component_and_configurations(
+           %{
+             dashboard_id: dashboard.id,
+             component_id: params["component_id"],
+             user_id: user.id
+           },
+           configs
+         ) do
       {:ok, dc} ->
         {:noreply,
          assign(
            socket,
            :dashboard_components,
-           Enum.reverse([dc | Enum.reverse(socket.assigns.dashboard_components)])
+           Dashboards.get_dashboard!(dashboard.id, user.id) |> Map.get(:dashboard_components)
          )}
     end
   end
 
   @impl true
-  def handle_event("add-component", %{"component-id" => component_id}, socket) do
+  def handle_event(
+        "add-component",
+        %{"component" => %{"component_id" => component_id} = params},
+        socket
+      ) do
     user = Accounts.get_user_by_session_token(socket.assigns.user_token)
     dashboard = socket.assigns.dashboard
 
     # TODO: handle the error!
-    # TODO: is the double-reverse of the list faster or slower than appending the list directly?
     case Dashboards.create_dashboard_component(%{
            dashboard_id: dashboard.id,
            component_id: component_id,
@@ -64,7 +82,7 @@ defmodule DashboardWeb.DashboardLive.Layout do
          assign(
            socket,
            :dashboard_components,
-           Enum.reverse([dc | Enum.reverse(socket.assigns.dashboard_components)])
+           Dashboards.get_dashboard!(dashboard.id, user.id) |> Map.get(:dashboard_components)
          )}
     end
   end

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.html.leex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.html.leex
@@ -36,9 +36,16 @@
   <h2>Active Components</h2>
   <div id="sortable-container" phx-hook="ComponentDragAndDrop" style="display: flex; flex-direction: row; flex-wrap: wrap; border: 1px solid #eee;">
     <%= for dc <- @dashboard_components do %>
-      <div style="background: white; display: flex; align-items: center; border: 1px solid #666; padding: 0.5em; margin: 0 0.5em 0.5em 0;" class="sortable" data-dc-id="<%= dc.id %>">
-        <span phx-click="remove-component" phx-value-dc-id="<%= dc.id %>" style="cursor: pointer; color: red; margin-right: 0.2em; font-size: 1.2em;">-</span>
-        <%= dc.sequence %>: <%= dc.component.name %>
+      <div style="background: white; display: flex; flex-direction: column; border: 1px solid #666; padding: 0.5em; margin: 0 0.5em 0.5em 0;" class="sortable" data-dc-id="<%= dc.id %>">
+        <div style="display: flex; flex-direction: row; align-items: center;">
+          <span phx-click="remove-component" phx-value-dc-id="<%= dc.id %>" style="cursor: pointer; color: red; margin-right: 0.2em; font-size: 1.2em;">-</span>
+          <%= dc.sequence %>: <%= dc.component.name %>
+        </div>
+        <%= for config <- dc.configurations do %>
+          <div>
+            <%= config.configuration.label %>: <%= config.value %>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.html.leex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.html.leex
@@ -12,7 +12,7 @@
   <h2>Available Components</h2>
   <div style="display: flex; flex-direction: row;">
     <%= for component <- @all_components do %>
-      <%= f = form_for :component, "#", id: "component-#{component.id}-form", phx_submit: "save" %>
+      <%= f = form_for :component, "#", id: "component-#{component.id}-form", phx_submit: "add-component" %>
         <div style="display: flex; flex-direction: column; align-items: flex-start; border: 1px solid #666; padding: 0.5em; margin-right: 0.5em;">
           <%= hidden_input f, :component_id, value: component.id %>
           <%= component.name %>
@@ -20,8 +20,8 @@
             <div style="display: flex; flex-direction row;">
               <%= for configuration <- component.configurations do %>
                 <%= label f, :value, configuration.label, class: "block text-gray-500 font-bold leading-7 py-2 text-right" %>
-                <%= text_input f, :value, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded py-2 px-3 text-gray-700 focus:outline-none focus:bg-white focus:border-blue-500" %>
-                <%= hidden_input f, :configuration_id, value: configuration.id %>
+                <%= text_input f, "configuration_#{configuration.id}", class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded py-2 px-3 text-gray-700 focus:outline-none focus:bg-white focus:border-blue-500" %>
+                <%= hidden_input f, :has_config, value: true %>
               <% end %>
             </div>
           <% end %>

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.html.leex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.html.leex
@@ -12,9 +12,22 @@
   <h2>Available Components</h2>
   <div style="display: flex; flex-direction: row;">
     <%= for component <- @all_components do %>
-      <div style="display: flex; align-items: center; border: 1px solid #666; padding: 0.5em; margin-right: 0.5em;" phx-click="add-component" phx-value-component-id=<%= component.id %>>
-        <span style="color: green; margin-right: 0.2em; font-size: 1.2em;">+</span> <%= component.name %>
-      </div>
+      <%= f = form_for :component, "#", id: "component-#{component.id}-form", phx_submit: "save" %>
+        <div style="display: flex; flex-direction: column; align-items: flex-start; border: 1px solid #666; padding: 0.5em; margin-right: 0.5em;">
+          <%= hidden_input f, :component_id, value: component.id %>
+          <%= component.name %>
+          <%= if length(component.configurations) > 0 do %>
+            <div style="display: flex; flex-direction row;">
+              <%= for configuration <- component.configurations do %>
+                <%= label f, :value, configuration.label, class: "block text-gray-500 font-bold leading-7 py-2 text-right" %>
+                <%= text_input f, :value, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded py-2 px-3 text-gray-700 focus:outline-none focus:bg-white focus:border-blue-500" %>
+                <%= hidden_input f, :configuration_id, value: configuration.id %>
+              <% end %>
+            </div>
+          <% end %>
+          <%= submit "Add to Dashboard", class: "shadow bg-blue-500 hover:bg-blue-400 focus:shadow-outline focus:outline-none text-white py-2 px-4 rounded text-sm" %>
+        </div>
+      </form>
     <% end %>
   </div>
 </div>

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.ex
@@ -62,6 +62,19 @@ defmodule DashboardWeb.DashboardLive.Show do
   end
 
   @impl true
+  def handle_event("keyboard-shortcut", %{"key" => "L"}, socket) do
+    {:noreply,
+     push_redirect(socket,
+       to: Routes.dashboard_layout_path(socket, :edit, socket.assigns.dashboard)
+     )}
+  end
+
+  @impl true
+  def handle_event("keyboard-shortcut", _, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
   def terminate(_reason, socket) do
     socket.assigns.component_subscriptions
     |> Enum.each(fn {name, _pid} -> Dashboard.Stores.unsubscribe(name, self()) end)

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.html.leex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/show.html.leex
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-5 gap-8 p-8">
+<div class="grid grid-cols-5 gap-8 p-8" phx-window-keyup="keyboard-shortcut">
   <%= for dc <- @components do %>
     <%= live_component(@socket,
                       Dashboard.Dashboards.Component.to_module(dc.component),


### PR DESCRIPTION
Allow components to be configured when added to a dashboard. There is no error handling, nor any validations. This is mostly a placeholder to make sure the UI and the backend speak the same language.

Also added a "L" (`shift-l`) keyboard shortcut to get from a dashboard's show view to its layout.

![Screen Shot 2020-05-04 at 5 26 31 PM](https://user-images.githubusercontent.com/385726/81025785-a10e5e00-8e2c-11ea-9e5c-0cc6830d9bed.png)
