### PR TITLE
fix(reordering): don't attempt to reorder if it's just the same sequence

### DIFF
--- a/apps/dashboard/lib/dashboard/dashboards.ex
+++ b/apps/dashboard/lib/dashboard/dashboards.ex
@@ -320,6 +320,14 @@ defmodule Dashboard.Dashboards do
     )
   end
 
+  @doc """
+  Reorder the sequencing of the components
+
+  However, don't attempt to resequence the component if the new
+  sequence number and the old are equal.
+  """
+  def reorder_component(%{sequence: sequence} = dc, sequence), do: {:ok, dc}
+
   def reorder_component(%DashboardComponent{} = dc, new_sequence) do
     {resequence_others_query, direction} =
       cond do

--- a/apps/dashboard_web/assets/js/dragAndDropComponents.js
+++ b/apps/dashboard_web/assets/js/dragAndDropComponents.js
@@ -20,11 +20,13 @@ export default {
     // sortable.on('drag:move', () => console.log('drag:move'))
     // sortable.on('drag:stop', () => console.log('drag:stop'))
     sortable.on("sortable:stop", (e) => {
-      const dcId = e.data.dragEvent.data.source.dataset.dcId
-      this.pushEvent("reorder-component", {
-        dc_id: dcId,
-        new_sequence: e.newIndex,
-      })
+      if (e.newIndex !== e.oldIndex) {
+        const dcId = e.data.dragEvent.data.source.dataset.dcId
+        this.pushEvent("reorder-component", {
+          dc_id: dcId,
+          new_sequence: e.newIndex,
+        })
+      }
     })
   },
 }

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
@@ -120,14 +120,21 @@ defmodule DashboardWeb.DashboardLive.Layout do
     dashboard = socket.assigns.dashboard
 
     # TODO: handle error
-    dashboard
-    |> Dashboards.get_dashboard_component_of_dashboard!(dc_id)
-    |> Dashboards.reorder_component(new_sequence)
-    |> case do
-      {:ok, _} ->
-        user = Accounts.get_user_by_session_token(socket.assigns.user_token)
-        dashboard = Dashboards.get_dashboard!(dashboard.id, user.id)
-        {:noreply, assign(socket, :dashboard_components, dashboard.dashboard_components)}
+    dc =
+      dashboard
+      |> Dashboards.get_dashboard_component_of_dashboard!(dc_id)
+
+    if dc.sequence != new_sequence do
+      dc
+      |> Dashboards.reorder_component(new_sequence)
+      |> case do
+        {:ok, _} ->
+          user = Accounts.get_user_by_session_token(socket.assigns.user_token)
+          dashboard = Dashboards.get_dashboard!(dashboard.id, user.id)
+          {:noreply, assign(socket, :dashboard_components, dashboard.dashboard_components)}
+      end
+    else
+      {:noreply, socket}
     end
   end
 

--- a/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/dashboard_live/layout.ex
@@ -52,7 +52,7 @@ defmodule DashboardWeb.DashboardLive.Layout do
            },
            configs
          ) do
-      {:ok, dc} ->
+      {:ok, _dc} ->
         {:noreply,
          assign(
            socket,
@@ -65,7 +65,7 @@ defmodule DashboardWeb.DashboardLive.Layout do
   @impl true
   def handle_event(
         "add-component",
-        %{"component" => %{"component_id" => component_id} = params},
+        %{"component" => %{"component_id" => component_id} = _params},
         socket
       ) do
     user = Accounts.get_user_by_session_token(socket.assigns.user_token)
@@ -77,7 +77,7 @@ defmodule DashboardWeb.DashboardLive.Layout do
            component_id: component_id,
            user_id: user.id
          }) do
-      {:ok, dc} ->
+      {:ok, _dc} ->
         {:noreply,
          assign(
            socket,


### PR DESCRIPTION
If a user picked up the first component and dropped it to the left, it
would resequence the component to have the sequence of -1. This is
obviously not what we want and produced bugs. Instead, make sure that
the new sequence doesn't equal the old before resequencing. Do this in
three places: one in the view's javascript event, one closer to the
view, and one closer to the database.