### PR TITLE
change: always update components with relative times

### DIFF
--- a/apps/dashboard_web/lib/dashboard_web/live/components/form_submissions.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/components/form_submissions.ex
@@ -12,11 +12,15 @@ defmodule DashboardWeb.Components.FormSubmissions do
     id = genserver_id(assigns, assigns.dashboard_component)
     submissions = Dashboard.Stores.get(data_module(), id, :submissions, [])
     form_name = Dashboard.Stores.get(data_module(), id, :form_name)
+    last_update = Dashboard.Stores.get(data_module(), id, :last_update)
+    included = Dashboard.Stores.get(data_module(), id, :included, [])
 
     {:ok,
      socket
      |> assign(:submissions, submissions)
      |> assign(:genserver_id, id)
+     |> assign(:last_update, last_update)
+     |> assign(:included, included)
      |> assign(:title, "Form Submissions - #{form_name}")
      |> assign(:product, :people)
      |> assign(:icon, "product_people-logomark")
@@ -25,8 +29,6 @@ defmodule DashboardWeb.Components.FormSubmissions do
 
   @impl true
   def render(assigns) do
-    included = Dashboard.Stores.get(data_module(), assigns.genserver_id, :included)
-
     assigns =
       assigns
       |> Map.put(:table_columns, [
@@ -35,7 +37,7 @@ defmodule DashboardWeb.Components.FormSubmissions do
             person_id = item["relationships"]["person"]["data"]["id"]
 
             person =
-              included
+              assigns.included
               |> Enum.find(fn include ->
                 include["type"] == "Person" && include["id"] == person_id
               end)

--- a/apps/dashboard_web/lib/dashboard_web/live/components/person_updated.ex
+++ b/apps/dashboard_web/lib/dashboard_web/live/components/person_updated.ex
@@ -10,10 +10,12 @@ defmodule DashboardWeb.Components.PersonUpdated do
   @impl true
   def update(assigns, socket) do
     people = Dashboard.Stores.get(data_module(), genserver_id(assigns), :people, [])
+    last_update = Dashboard.Stores.get(data_module(), genserver_id(assigns), :last_update)
 
     {:ok,
      socket
      |> assign(:people, people)
+     |> assign(:last_update, last_update)
      |> assign(:title, "Recently Updated")
      |> assign(:product, :people)
      |> assign(:icon, "product_people-logomark")


### PR DESCRIPTION
The way it works is to always push the last update into the assigns. That means the component thinks there is new information and will re-render.

![ScreenFlow](https://user-images.githubusercontent.com/385726/81360085-c4851300-908f-11ea-96ad-1044ef54b553.gif)
