### PR TITLE
feat: require Planning Center access setup

### DIFF
--- a/apps/dashboard_web/lib/dashboard_web/router.ex
+++ b/apps/dashboard_web/lib/dashboard_web/router.ex
@@ -70,6 +70,10 @@ defmodule DashboardWeb.Router do
     get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
 
     get "/oauth/complete", OauthController, :new
+  end
+
+  scope "/", DashboardWeb do
+    pipe_through [:browser, :require_authenticated_user, :require_access_token]
 
     live "/dashboards", DashboardLive.Index, :index
     live "/dashboards/new", DashboardLive.Index, :new


### PR DESCRIPTION
Before getting to the dashboard pages, we need access to a user's
Planning Center account. This redirects the user back to the settings
page if they haven't configured their account yet.

<img width="1388" alt="Screen Shot 2020-05-07 at 6 48 31 PM" src="https://user-images.githubusercontent.com/385726/81361833-4aa35880-9094-11ea-96e3-e13bada809eb.png">
