### PR TITLE
chore: setup tailwind css purging

### DIFF
--- a/apps/dashboard_web/assets/package.json
+++ b/apps/dashboard_web/assets/package.json
@@ -3,7 +3,7 @@
   "description": " ",
   "license": "MIT",
   "scripts": {
-    "deploy": "webpack --mode production",
+    "deploy": "NODE_ENV=production webpack --mode production",
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {

--- a/apps/dashboard_web/assets/tailwind.config.js
+++ b/apps/dashboard_web/assets/tailwind.config.js
@@ -1,5 +1,11 @@
 module.exports = {
-  purge: [],
+  purge: [
+    "../**/*.html.eex",
+    "../**/*.html.leex",
+    "../**/views/**/*.ex",
+    "../**/lives/**/*.ex",
+    "./js/**/*.js",
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Drops `css/app.css` from `1.78 MB` to `20.6 KB`. Seems pretty good.